### PR TITLE
Implementing redis locking

### DIFF
--- a/redisLock/lock_test.go
+++ b/redisLock/lock_test.go
@@ -1,0 +1,50 @@
+package redisLock
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/garyburd/redigo/redis"
+	"github.com/schyntax/go-schtick"
+)
+
+var pool = &redis.Pool{
+	MaxIdle:     3,
+	IdleTimeout: 240 * time.Second,
+	Dial: func() (redis.Conn, error) {
+		c, err := redis.Dial("tcp", "localhost:6379", redis.DialDatabase(2))
+		if err != nil {
+			return nil, err
+		}
+		return c, err
+	},
+}
+
+var count = new(int64)
+
+func TestMultiple(t *testing.T) {
+	locker := New(pool.Get)
+
+	//try to make sure we are exactly halfway between seconds when we start
+	offset := time.Now().Sub(time.Now().Truncate(time.Second))
+	time.Sleep(time.Second - offset + (500 * time.Millisecond))
+
+	sch := schtick.New(nil)
+	sch.AddTaskWithDefaults("taskA", "s(*)", locker.Wrap(run))
+
+	sch2 := schtick.New(nil)
+	sch2.AddTaskWithDefaults("taskA", "s(*)", locker.Wrap(run))
+
+	time.Sleep(3 * time.Second)
+
+	if *count != 3 {
+		t.Fatalf("Expected exactly 3 events, but received %d.", *count)
+	}
+
+}
+
+func run(task schtick.Task, timeIntendedToRun time.Time) error {
+	atomic.AddInt64(count, 1)
+	return nil
+}

--- a/redisLock/redis.go
+++ b/redisLock/redis.go
@@ -1,0 +1,78 @@
+// package residLock provides a way to use redis to lock tasks before running them.
+// This will ensure that only one server runs a task in any given interval.
+// Fully compatible with other language implementations.
+package redisLock
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/garyburd/redigo/redis"
+	"github.com/schyntax/go-schtick"
+)
+
+type Locker interface {
+	Wrap(schtick.TaskCallback) schtick.TaskCallback
+
+	SetHostname(string)
+}
+
+type taskLocker struct {
+	connect func() redis.Conn
+	host    string
+	prefix  string
+	lastKey string
+}
+
+func (t *taskLocker) SetHostname(n string) {
+	t.host = n
+}
+
+func New(connect func() redis.Conn) Locker {
+	host, err := os.Hostname()
+	if err != nil {
+		host = "???"
+	}
+	return &taskLocker{
+		connect: connect,
+		host:    host,
+		prefix:  "schyntax",
+		lastKey: "schyntax_last",
+	}
+}
+
+const LOCK_SCRIPT = `
+if redis.call('set', KEYS[1], KEYS[2], 'nx', 'px', KEYS[3])
+then
+    redis.call('hset', KEYS[4], KEYS[5], KEYS[6])
+    return 1
+else
+    return 0
+end
+`
+
+var script = redis.NewScript(6, LOCK_SCRIPT)
+
+func (t *taskLocker) Wrap(cb schtick.TaskCallback) schtick.TaskCallback {
+	return func(task schtick.Task, timeIntendedToRun time.Time) error {
+		const format = "2006-01-02T15:04:05.0000000-07:00"
+		iso := timeIntendedToRun.Format(format)
+		lockKey := fmt.Sprintf("%s;%s;%s", t.prefix, task.Name(), iso)
+		lastLockValue := fmt.Sprintf("%s;%s;%s", iso, time.Now().UTC().Format(format), t.host)
+
+		px := int(time.Hour / time.Millisecond) // TODO: window?
+
+		args := []interface{}{lockKey, t.host, px, t.lastKey, task.Name(), lastLockValue}
+		conn := t.connect()
+		lockAquired, err := redis.Int(script.Do(conn, args...))
+		if err != nil {
+			return err
+		}
+		if lockAquired == 1 {
+			return cb(task, timeIntendedToRun)
+		}
+		return nil
+	}
+
+}


### PR DESCRIPTION
An initial implementation of redis locking in go. Modeled closely after c# implementation, and tested with the c# to confirm that they do lock each other. 

Added into subpackage of go-schtick. I don't see a need for a separate repo for this. I actually think all of go-schtick could go in `github.com/schyntax/go-schyntax/schtick`, but thats another discussion.

Depends on http://github.com/garyburd/redigo, which is definitely the most popular redis client for go.
